### PR TITLE
Add custom keyword highlighting for Kotlin in dark-plus theme

### DIFF
--- a/src/main/resources/theme/dark-plus.xml
+++ b/src/main/resources/theme/dark-plus.xml
@@ -1326,5 +1326,29 @@
             </value>
         </option>
 
+        <!-- Custom Keywords for use with Kotlin DS L-->
+
+        <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="d9a996"/>
+            </value>
+        </option>
+        <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="d29daa"/>
+            </value>
+        </option>
+        <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="7cb2df"/>
+            </value>
+        </option>
+        <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="92ddce"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+
     </attributes>
 </scheme>


### PR DESCRIPTION
Introduced four new custom keyword attributes with specific colors and effects to enhance Kotlin DSL syntax highlighting. This update improves the developer experience by making Kotlin code more readable and visually distinct in the dark-plus theme.